### PR TITLE
Change date format of ezLog::write to ISO8601

### DIFF
--- a/lib/ezfile/classes/ezlog.php
+++ b/lib/ezfile/classes/ezlog.php
@@ -46,8 +46,8 @@ class eZLog
         $logFile = @fopen( $fileName, "a" );
         if ( $logFile )
         {
-            $time = strftime( "%b %d %Y %H:%M:%S", strtotime( "now" ) );
-            $logMessage = "[ " . $time . " ] $message\n";
+            $time = date(DateTime::ISO8601);
+            $logMessage = $time . " $message\n";
             @fwrite( $logFile, $logMessage );
             @fclose( $logFile );
             if ( !$fileExisted )


### PR DESCRIPTION
This format is easier to parse: no language dependency in month string and no white spaces as separator of date components.
The use of constant DateTime::ISO8601 (instead of the simpler 'c' parameter) is just to make it more readable: the class DateTime is available starting from PHP 5.5 so should be safe use it, but if we have still some environment running on 5.4 we can fallback to 'c' paramenter.

This change could break existing scripts that parse the old format, MERGE WITH CAUTION 